### PR TITLE
Support internationalization for plugin

### DIFF
--- a/__tests__/MiradorImageTools.test.js
+++ b/__tests__/MiradorImageTools.test.js
@@ -22,6 +22,7 @@ function createWrapper(props) {
       windowId="x"
       width="sm"
       theme={mockPalette}
+      t={() => {}}
       {...props}
     />,
   );

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "mirador": "^3.0.0-rc.2",
+    "mirador": "^3.0.0-rc.4",
     "react": "16.x",
     "react-dom": "16.x"
   },
@@ -43,7 +43,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^24.9.0",
-    "mirador": "^3.0.0-rc.2",
+    "mirador": "^3.0.0-rc.4",
     "nwb": "0.23.x",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/src/plugins/MiradorImageTools.js
+++ b/src/plugins/MiradorImageTools.js
@@ -160,6 +160,7 @@ class MiradorImageTools extends Component {
         grayscale = 0,
         invert = 0,
       },
+      t,
     } = this.props;
 
     if (!viewer || !enabled) return null;
@@ -172,7 +173,7 @@ class MiradorImageTools extends Component {
     const toggleButton = (
       <div className={(isSmallDisplay && open) ? classes.borderContainer : ''}>
         <MiradorMenuButton
-          aria-label={open ? 'Collapse image tools' : 'Expand image tools'}
+          aria-label={t('collapse', { context: open ? 'open' : 'close' })}
           containerId={containerId}
           onClick={this.toggleState}
         >
@@ -189,18 +190,18 @@ class MiradorImageTools extends Component {
           <div className={classes.borderContainer}>
             <ImageRotation
               containerId={containerId}
-              label="Rotate right"
+              label={t('rotateRight')}
               onClick={() => this.toggleRotate(90)}
               variant="right"
             />
             <ImageRotation
               containerId={containerId}
-              label="Rotate left"
+              label={t('rotateLeft')}
               onClick={() => this.toggleRotate(-90)}
               variant="left"
             />
             <ImageFlip
-              label="Flip"
+              label={t('flip')}
               onClick={this.toggleFlip}
               flipped={flip}
               containerId={containerId}
@@ -209,7 +210,7 @@ class MiradorImageTools extends Component {
           <div className={classes.borderContainer}>
             <ImageTool
               type="brightness"
-              label="Brightness"
+              label={t('brightness')}
               max={200}
               windowId={windowId}
               value={brightness}
@@ -221,7 +222,7 @@ class MiradorImageTools extends Component {
             </ImageTool>
             <ImageTool
               type="contrast"
-              label="Contrast"
+              label={t('contrast')}
               max={200}
               windowId={windowId}
               value={contrast}
@@ -233,7 +234,7 @@ class MiradorImageTools extends Component {
             </ImageTool>
             <ImageTool
               type="saturate"
-              label="Saturation"
+              label={t('saturation')}
               max={200}
               windowId={windowId}
               value={saturate}
@@ -246,7 +247,7 @@ class MiradorImageTools extends Component {
             <ImageTool
               type="grayscale"
               variant="toggle"
-              label="Greyscale"
+              label={t('greyscale')}
               windowId={windowId}
               value={grayscale}
               backgroundColor={backgroundColor}
@@ -259,7 +260,7 @@ class MiradorImageTools extends Component {
             <ImageTool
               type="invert"
               variant="toggle"
-              label="Invert Colors"
+              label={t('invert')}
               windowId={windowId}
               value={invert}
               foregroundColor={foregroundColor}
@@ -271,7 +272,7 @@ class MiradorImageTools extends Component {
           </div>
           <div className={isSmallDisplay ? '' : classes.borderContainer}>
             <MiradorMenuButton
-              aria-label="Revert image"
+              aria-label={t('revert')}
               containerId={containerId}
               onClick={this.handleReset}
             >
@@ -291,6 +292,7 @@ MiradorImageTools.propTypes = {
   containerId: PropTypes.string.isRequired,
   enabled: PropTypes.bool,
   open: PropTypes.bool,
+  t: PropTypes.func.isRequired,
   theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   updateViewport: PropTypes.func.isRequired,
   updateWindow: PropTypes.func.isRequired,

--- a/src/plugins/miradorImageToolsPlugin.js
+++ b/src/plugins/miradorImageToolsPlugin.js
@@ -3,6 +3,7 @@ import * as actions from 'mirador/dist/es/src/state/actions';
 import { getWindowConfig, getViewer, getContainerId } from 'mirador/dist/es/src/state/selectors';
 import MiradorImageTools from './MiradorImageTools';
 import MiradorImageToolsMenuItem from './MiradorImageToolsMenuItem';
+import translations from '../translations';
 
 export default [
   {
@@ -19,6 +20,9 @@ export default [
     }),
     mode: 'add',
     component: withTheme(MiradorImageTools),
+    config: {
+      translations,
+    },
   },
   {
     target: 'WindowTopBarPluginMenu',

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,17 @@
+const translations = {
+  en: {
+    brightness: 'Brightness',
+    collapse_open: 'Collapse image tools',
+    collapse_close: 'Expand image tools',
+    contrast: 'Contrast',
+    flip: 'Flip',
+    greyscale: 'Greyscale',
+    invert: 'Invert colors',
+    revert: 'Revert image',
+    rotateLeft: 'Rotate left',
+    rotateRight: 'Rotate right',
+    saturation: 'Saturation',
+  },
+};
+
+export default translations;


### PR DESCRIPTION
Will require https://github.com/ProjectMirador/mirador/pull/3228 but aims to provide a pattern for: https://github.com/ProjectMirador/mirador/issues/3020

## How it works?

Plugins will get props from its add/wrap ancestor. So if the target is wrapped `withTranslation` we already get access to the correct i18next context.