### PR TITLE
Add webpack aliases and move reactdom to an external dependency

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   type: 'react-component',
   npm: {
@@ -5,8 +7,17 @@ module.exports = {
     umd: {
       global: 'MiradorImageTools',
       externals: {
-        react: 'React'
-      }
-    }
-  }
-}
+        react: 'React',
+        'react-dom': 'ReactDom',
+      },
+    },
+  },
+  webpack: {
+    aliases: {
+      '@material-ui/core': path.resolve('./', 'node_modules', '@material-ui/core'),
+      '@material-ui/styles': path.resolve('./', 'node_modules', '@material-ui/styles'),
+      react: path.resolve('./', 'node_modules', 'react'),
+      'react-dom': path.resolve('./', 'node_modules', 'react-dom'),
+    },
+  },
+};


### PR DESCRIPTION
On the path to better understand the dependencies and ultimately provide umds that can be used by adopters without webpack.