### PR TITLE
Fix default state inconsistent with README

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,6 +5,7 @@ const config = {
   id: 'demo',
   windows: [{
     imageToolsEnabled: true,
+    imageToolsOpen: true,
     manifestId: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest',
   }],
   theme: {

--- a/src/plugins/miradorImageToolsPlugin.js
+++ b/src/plugins/miradorImageToolsPlugin.js
@@ -11,8 +11,8 @@ export default [
       updateViewport: actions.updateViewport,
     },
     mapStateToProps: (state, { windowId }) => ({
-      enabled: getWindowConfig(state, { windowId }).imageToolsEnabled,
-      open: getWindowConfig(state, { windowId }).imageToolsOpen,
+      enabled: getWindowConfig(state, { windowId }).imageToolsEnabled || false,
+      open: getWindowConfig(state, { windowId }).imageToolsOpen || false,
       viewConfig: getViewer(state, { windowId }) || {},
     }),
     mode: 'add',
@@ -26,7 +26,7 @@ export default [
       updateWindow: actions.updateWindow,
     },
     mapStateToProps: (state, { windowId }) => ({
-      enabled: getWindowConfig(state, { windowId }).imageToolsEnabled,
+      enabled: getWindowConfig(state, { windowId }).imageToolsEnabled || false,
     }),
   },
 ];


### PR DESCRIPTION
The README states that, in absence of an `imageToolsEnabled` setting in the options, the plugin is **disabled** by default. It states the same for `imageToolsOpen`.

However, the actual behavior was the opposite of that: Due to the presence of a `true` defaultProp for both values, they would be **enabled** in the absence of their respective config key.

This PR fixes this inconsistency by explicitly setting `enabled` and `open` to `false` if the configuration key is absent (i.e. `undefined`).