### PR TITLE
Add containerId prop to all MiradorMenuButton instances

### DIFF
--- a/src/plugins/ImageFlip.js
+++ b/src/plugins/ImageFlip.js
@@ -24,6 +24,7 @@ export default class ImageFlip extends Component {
 
 ImageFlip.propTypes = {
   backgroundColor: PropTypes.string,
+  containerId: PropTypes.string.isRequired,
   foregroundColor: PropTypes.string,
   flipped: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,

--- a/src/plugins/ImageRotation.js
+++ b/src/plugins/ImageRotation.js
@@ -19,6 +19,7 @@ export default class ImageRotation extends Component {
 }
 
 ImageRotation.propTypes = {
+  containerId: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   variant: PropTypes.string.isRequired,
 };

--- a/src/plugins/ImageTool.js
+++ b/src/plugins/ImageTool.js
@@ -61,7 +61,7 @@ class ImageTool extends Component {
 
   render() {
     const {
-      children, label, max, min, value, type, variant, windowId,
+      children, containerId, label, max, min, value, type, variant, windowId,
       foregroundColor, classes, width,
     } = this.props;
     const { open } = this.state;
@@ -80,6 +80,7 @@ class ImageTool extends Component {
         <MiradorMenuButton
           id={`${id}-label`}
           aria-label={label}
+          containerId={containerId}
           onClick={this.handleClick}
           aria-expanded={open}
           aria-controls={id}
@@ -112,6 +113,7 @@ ImageTool.propTypes = {
   children: PropTypes.node.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   classes: PropTypes.object.isRequired,
+  containerId: PropTypes.string.isRequired,
   foregroundColor: PropTypes.string,
   label: PropTypes.string.isRequired,
   min: PropTypes.number,

--- a/src/plugins/MiradorImageTools.js
+++ b/src/plugins/MiradorImageTools.js
@@ -150,7 +150,7 @@ class MiradorImageTools extends Component {
 
   render() {
     const {
-      classes, enabled, open, viewer, windowId, width,
+      classes, containerId, enabled, open, viewer, windowId, width,
       theme: { palette },
       viewConfig: {
         flip = false,
@@ -173,6 +173,7 @@ class MiradorImageTools extends Component {
       <div className={(isSmallDisplay && open) ? classes.borderContainer : ''}>
         <MiradorMenuButton
           aria-label={open ? 'Collapse image tools' : 'Expand image tools'}
+          containerId={containerId}
           onClick={this.toggleState}
         >
           { open ? <CloseSharpIcon /> : <TuneSharpIcon /> }
@@ -187,11 +188,13 @@ class MiradorImageTools extends Component {
         <React.Fragment>
           <div className={classes.borderContainer}>
             <ImageRotation
+              containerId={containerId}
               label="Rotate right"
               onClick={() => this.toggleRotate(90)}
               variant="right"
             />
             <ImageRotation
+              containerId={containerId}
               label="Rotate left"
               onClick={() => this.toggleRotate(-90)}
               variant="left"
@@ -200,6 +203,7 @@ class MiradorImageTools extends Component {
               label="Flip"
               onClick={this.toggleFlip}
               flipped={flip}
+              containerId={containerId}
             />
           </div>
           <div className={classes.borderContainer}>
@@ -210,6 +214,7 @@ class MiradorImageTools extends Component {
               windowId={windowId}
               value={brightness}
               foregroundColor={foregroundColor}
+              containerId={containerId}
               onChange={this.handleChange('brightness')}
             >
               <BrightnessIcon />
@@ -221,6 +226,7 @@ class MiradorImageTools extends Component {
               windowId={windowId}
               value={contrast}
               foregroundColor={foregroundColor}
+              containerId={containerId}
               onChange={this.handleChange('contrast')}
             >
               <ContrastIcon style={{ transform: 'rotate(180deg)' }} />
@@ -232,6 +238,7 @@ class MiradorImageTools extends Component {
               windowId={windowId}
               value={saturate}
               foregroundColor={foregroundColor}
+              containerId={containerId}
               onChange={this.handleChange('saturate')}
             >
               <GradientIcon />
@@ -244,6 +251,7 @@ class MiradorImageTools extends Component {
               value={grayscale}
               backgroundColor={backgroundColor}
               foregroundColor={foregroundColor}
+              containerId={containerId}
               onChange={this.handleChange('grayscale')}
             >
               <TonalityIcon />
@@ -255,6 +263,7 @@ class MiradorImageTools extends Component {
               windowId={windowId}
               value={invert}
               foregroundColor={foregroundColor}
+              containerId={containerId}
               onChange={this.handleChange('invert')}
             >
               <InvertColorsIcon />
@@ -263,6 +272,7 @@ class MiradorImageTools extends Component {
           <div className={isSmallDisplay ? '' : classes.borderContainer}>
             <MiradorMenuButton
               aria-label="Revert image"
+              containerId={containerId}
               onClick={this.handleReset}
             >
               <ReplaySharpIcon />
@@ -278,6 +288,7 @@ class MiradorImageTools extends Component {
 
 MiradorImageTools.propTypes = {
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  containerId: PropTypes.string.isRequired,
   enabled: PropTypes.bool,
   open: PropTypes.bool,
   theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/src/plugins/miradorImageToolsPlugin.js
+++ b/src/plugins/miradorImageToolsPlugin.js
@@ -1,6 +1,6 @@
 import withTheme from '@material-ui/core/styles/withTheme';
 import * as actions from 'mirador/dist/es/src/state/actions';
-import { getWindowConfig, getViewer } from 'mirador/dist/es/src/state/selectors';
+import { getWindowConfig, getViewer, getContainerId } from 'mirador/dist/es/src/state/selectors';
 import MiradorImageTools from './MiradorImageTools';
 import MiradorImageToolsMenuItem from './MiradorImageToolsMenuItem';
 
@@ -12,6 +12,7 @@ export default [
       updateViewport: actions.updateViewport,
     },
     mapStateToProps: (state, { windowId }) => ({
+      containerId: getContainerId(state),
       enabled: getWindowConfig(state, { windowId }).imageToolsEnabled || false,
       open: getWindowConfig(state, { windowId }).imageToolsOpen || false,
       viewConfig: getViewer(state, { windowId }) || {},


### PR DESCRIPTION
Without the prop, tooltips would be appended to the body and not to the Mirador container.
This had the effect of tooltips not rendering in fullscreen mode, since their elements would not be part of the fullscreen-scoped element.