### PR TITLE
fix: convert MiradorImageTools to functional component to fix no image bug

### DIFF
--- a/__tests__/MiradorImageTools.test.js
+++ b/__tests__/MiradorImageTools.test.js
@@ -19,6 +19,7 @@ function createWrapper(props) {
       windowId="x"
       width="sm"
       theme={mockPalette}
+      size={{ width: 100, height: 200 }}
       t={(k) => k}
       {...props}
     />,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@mui/material": "^5.x",
-    "mirador": "^4.0.0-alpha.1",
+    "mirador": "^4.0.0-alpha.4",
     "react": "18.x",
     "react-dom": "18.x"
   },
@@ -70,7 +70,7 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.4.3",
     "jest-puppeteer": "^9.0.2",
-    "mirador": "^4.0.0-alpha.1",
+    "mirador": "^4.0.0-alpha.4",
     "puppeteer": "^21.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,3 +1,1 @@
 import '@testing-library/jest-dom'
-import sizeMe from 'react-sizeme';
-sizeMe.noPlaceholders = true;

--- a/src/plugins/MiradorImageTools.js
+++ b/src/plugins/MiradorImageTools.js
@@ -27,9 +27,9 @@ const ToggleContainer = styled('div')(() => ({
 }));
 
 const ToolContainer = styled('div')(() => ({
-  display: 'flex',
   border: 0,
   borderImageSlice: 1,
+  display: 'flex',
 }));
 
 /** Styles for withStyles HOC */
@@ -77,15 +77,15 @@ const Root = styled('div')(({ small, theme: { palette } }) => {
 
 const MiradorImageTools = (({
   enabled,
+  innerRef,
   open,
-  viewer,
-  windowId,
-  viewConfig,
   size,
+  t,
   updateViewport,
   updateWindow,
-  t,
-  innerRef,
+  viewer,
+  viewConfig,
+  windowId,
 }) => {
   const [isSmallDisplay, setIsSmallDisplay] = useState(false);
 
@@ -267,6 +267,10 @@ const MiradorImageTools = (({
 
 MiradorImageTools.propTypes = {
   enabled: PropTypes.bool,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.any,
+  ]).isRequired,
   open: PropTypes.bool,
   size: PropTypes.shape({
     width: PropTypes.number,
@@ -278,10 +282,6 @@ MiradorImageTools.propTypes = {
   viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   viewConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   windowId: PropTypes.string.isRequired,
-  innerRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.any,
-  ]).isRequired,
 };
 
 MiradorImageTools.defaultProps = {


### PR DESCRIPTION
I converted the MiradorImageTools class component to a functional one, due the usage of hooks inside the mirador `withSize`  HOC.

For usage i had to install a prepublish build as described by [lutzhelm](https://github.com/ProjectMirador/mirador-image-tools/issues/38#issuecomment-2491418747) here.
