### PR TITLE
Make eslint happy, add missing comma in hungarian translation

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -57,7 +57,7 @@ const translations = {
     rotateLeft: 'Forgatás balra',
     rotateRight: 'Forgatás jobbra',
     saturation: 'Színtelítettség',
-    show: 'Képeszközök megjelenítése'
+    show: 'Képeszközök megjelenítése',
   },
   it: {
     brightness: 'Luminosità',


### PR DESCRIPTION
Removes "Missing trailing comma" error (eslint rule comma-dangle)