### PR TITLE
Add react-i18next to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "mirador": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0",
     "vite": "^6.0.0",
     "vitest": "^3.0.0",
     "vitest-fetch-mock": "^0.4.2"


### PR DESCRIPTION
I am guessing something about how the new Vite 7 is bundling Mirador 4.1.0 was causing issues and giving me `NO_I18NEXT_INSTANCE` in the Netlify build as an error.

Looking at our other plugins, the dependency is also in devDependencies.